### PR TITLE
Catching the upload.dataUrl being rejected

### DIFF
--- a/src/data-url.js
+++ b/src/data-url.js
@@ -94,9 +94,9 @@
       });
 
       if (disallowObjectUrl) {
-        p = file.$$ngfDataUrlPromise = deferred.promise;
+        p = file.$$ngfDataUrlPromise = deferred.promise.catch(angular.noop);
       } else {
-        p = file.$$ngfBlobUrlPromise = deferred.promise;
+        p = file.$$ngfBlobUrlPromise = deferred.promise.catch(angular.noop);
       }
       p['finally'](function () {
         delete file[disallowObjectUrl ? '$$ngfDataUrlPromise' : '$$ngfBlobUrlPromise'];


### PR DESCRIPTION
Prevents the Angular 1.6 error log about "Possibly unhandled rejection" when promises aren't caught